### PR TITLE
Fix for this.registry.replace is not a function

### DIFF
--- a/lib/remote-ls.js
+++ b/lib/remote-ls.js
@@ -16,7 +16,7 @@ function RemoteLS (opts) {
     development: true, // include dev dependencies.
     optional: true, // include optional dependencies.
     verbose: false,
-    registry: require('registry-url'), // URL of registry to ls.
+    registry: require('registry-url')(), // URL of registry to ls.
     queue: async.queue(function (task, done) {
       _this._loadPackageJson(task, done)
     }, 8),


### PR DESCRIPTION
This fixes piranna/coverdeeps#1
